### PR TITLE
[FIX] Use Node's native https instead of spdy

### DIFF
--- a/packages/server/lib/server.js
+++ b/packages/server/lib/server.js
@@ -1,4 +1,5 @@
 import express from "express";
+import https from "https";
 import portscanner from "portscanner";
 import MiddlewareManager from "./middleware/MiddlewareManager.js";
 import {createReaderCollection} from "@ui5/fs/resourceFactory";
@@ -87,10 +88,7 @@ function _listen(app, port, changePortIfInUse, acceptRemoteConnections) {
  * @private
  */
 async function _addSsl({app, key, cert}) {
-	// Using spdy as http2 server as the native http2 implementation
-	// from Node v8.4.0 doesn't seem to work with express
-	const {default: spdy} = await import("spdy");
-	return spdy.createServer({cert, key}, app);
+        return https.createServer({key: key, cert: cert}, app);
 }
 
 
@@ -180,12 +178,6 @@ export async function serve(graph, {
 	await middlewareManager.applyMiddleware(app);
 
 	if (h2) {
-		const nodeVersion = parseInt(process.versions.node.split(".")[0], 10);
-		if (nodeVersion >= 24) {
-			log.error("ERROR: With Node v24, usage of HTTP/2 is no longer supported. Please check https://github.com/UI5/cli/issues/327 for updates.");
-			process.exit(1);
-		}
-
 		app = await _addSsl({app, key, cert});
 	}
 


### PR DESCRIPTION
Using native `https` from NodeJS instead of SPDY, which is not supported by Node >= 24.

According to [NodeJS Releases](https://nodejs.org/en/about/previous-releases), “v22 is about to enter Maintenance and v24 is about to become Active”. Unfortunately, this is a breaking change for UI5 CLI `serve` when using `--h2`, since we use `spdy`. According to the code comments, we use `spdy` because of Node v8.4.0 😬.

Tested the upgrade using Firefox Developer Edition (latest) on macOS 26 and NodeJS v24.9.0 with:
```shell
ui5 serve --verbose --port 1987 -o index.html --h2 --key ./infrastructure/certs/localhost.key --cert ./infrastructure/certs/localhost.crt --accept-remote-connections
```

Fixes: #327

--- 

**Thank you for your contribution!** 🙌

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [X] Reviewed the [Contributing Guidelines](https://github.com/UI5/cli/blob/main/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/UI5/cli/blob/main/CONTRIBUTING.md#how-to-contribute) section 
- [X] [No merge commits](https://github.com/UI5/cli/blob/main/docs/Guidelines.md#no-merge-commits)
- [X] [Correct commit message style](https://github.com/UI5/cli/blob/main/docs/Guidelines.md#commit-message-style)
