### PR TITLE
[INTERNAL] Remove "qs" lockfile overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3247,6 +3247,23 @@
 			"inBundle": true,
 			"license": "MIT"
 		},
+		"node_modules/@ui5/cli/node_modules/express/node_modules/qs": {
+			"version": "6.15.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+			"integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+			"inBundle": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"es-define-property": "^1.0.1",
+				"side-channel": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/@ui5/cli/node_modules/express/node_modules/raw-body": {
 			"version": "2.5.3",
 			"inBundle": true,

--- a/package.json
+++ b/package.json
@@ -41,11 +41,6 @@
 		"type": "git",
 		"url": "git@github.com:UI5/cli.git"
 	},
-	"overrides": {
-		"@ui5/cli": {
-			"qs": "^6.16.0"
-		}
-	},
 	"dependencies": {
 		"@ui5/builder": "^4.3.1",
 		"@ui5/cli": "^4.0.65",


### PR DESCRIPTION
The "qs" module does not only come via "@ui5/cli" but also via "@ui5/server", so the override should be defined generally.

Follow-up of https://github.com/UI5/cli/pull/1570