### PR TITLE
fix(cli): Remove unnecessary "Please" from certificate command messages

### DIFF
--- a/packages/cli/lib/cli/commands/certificate.js
+++ b/packages/cli/lib/cli/commands/certificate.js
@@ -78,10 +78,10 @@ async function handleGenerate(argv) {
 	// Inform the user before triggering the trust-store installation, which requires elevated
 	// privileges and therefore prompts for the root password (or shows a confirmation dialog on Windows).
 	if (process.platform === "win32") {
-		process.stderr.write("Please press allow in the opened dialog to confirm importing the newly created " +
+		process.stderr.write("Press 'Allow' in the opened dialog to confirm importing the newly created " +
 			"SSL certificate into the operating system and browsers.\n");
 	} else {
-		process.stderr.write("Please enter your root password to allow importing the newly created " +
+		process.stderr.write("Enter your root password to import the newly created " +
 			"SSL certificate into the operating system and browsers.\n");
 	}
 

--- a/packages/cli/test/lib/cli/commands/certificate.js
+++ b/packages/cli/test/lib/cli/commands/certificate.js
@@ -225,8 +225,7 @@ test.serial("ui5 certificate generate: prints trust-store notice before generati
 	await runGenerate(t, argv);
 
 	t.true(
-		t.context.consoleOutput.includes("importing the newly created") &&
-		t.context.consoleOutput.includes("operating system and browsers"),
+		t.context.consoleOutput.includes("SSL certificate into the operating system and browsers"),
 		"Prints notice about installing the certificate into the trust store"
 	);
 });


### PR DESCRIPTION
Address post-merge review feedback from PR #1560: the imperative voice without "Please" is more direct and consistent with CLI conventions.

Follow-up of https://github.com/UI5/cli/pull/1560#pullrequestreview-5102226266