### PR TITLE
refactor(server): Unify HTTP/HTTPS server creation in listener

### DIFF
--- a/packages/server/lib/serve/Supervisor.js
+++ b/packages/server/lib/serve/Supervisor.js
@@ -1,11 +1,10 @@
-import http from "node:http";
 import path from "node:path";
 import process from "node:process";
 import {EventEmitter} from "node:events";
 import {getLogger} from "@ui5/logger";
 import buildApp from "./stack.js";
 import attachLiveReloadServer from "../liveReload/server.js";
-import {listen, addSsl, announceListening} from "./httpListener.js";
+import {createServer, listen, announceListening} from "./httpListener.js";
 
 const log = getLogger("server:Supervisor");
 
@@ -226,11 +225,9 @@ class Supervisor extends EventEmitter {
 		// delegate to it before rethrowing. create() rethrows without handing the instance out, so
 		// the move to DESTROYED is not observable.
 		try {
-			const listenTarget = https ?
-				addSsl({app: dispatcher, key, cert}) :
-				http.createServer(dispatcher);
-			const {port, server} =
-				await listen(listenTarget, requestedPort, changePortIfInUse, acceptRemoteConnections);
+			const server = createServer({https, key, cert}, dispatcher);
+			const {port} =
+				await listen(server, requestedPort, changePortIfInUse, acceptRemoteConnections);
 			this.#httpServer = server;
 			this.#port = port;
 

--- a/packages/server/lib/serve/httpListener.js
+++ b/packages/server/lib/serve/httpListener.js
@@ -1,4 +1,5 @@
 import os from "node:os";
+import http from "node:http";
 import https from "node:https";
 import portscanner from "portscanner";
 
@@ -11,16 +12,35 @@ import portscanner from "portscanner";
  */
 
 /**
+ * Creates the Node server for the given config, wiring the request handler in. HTTPS when a key/cert
+ * pair is configured, plain HTTP otherwise. The returned server is not yet bound; pass it to
+ * {@link listen}.
+ *
+ * @param {object} parameters
+ * @param {boolean} parameters.https Whether to create an HTTPS server
+ * @param {string} [parameters.key] Private key to be used for https
+ * @param {string} [parameters.cert] Certificate to be used for https
+ * @param {Function} requestHandler The request handler to serve
+ * @returns {object} The (unbound) http/https server
+ * @private
+ */
+export function createServer({https: useHttps, key, cert}, requestHandler) {
+	return useHttps ?
+		https.createServer({key, cert}, requestHandler) :
+		http.createServer(requestHandler);
+}
+
+/**
  * Binds an HTTP/HTTPS server to a free port and resolves once it is listening.
  *
- * @param {object} app The http/https server to listen with
+ * @param {object} server The http/https server to listen with
  * @param {number} port Desired port to listen to
  * @param {boolean} changePortIfInUse If true and the port is already in use, an unused port is searched
  * @param {boolean} acceptRemoteConnections If true, listens to remote connections and not only to localhost
  * @returns {Promise<object>} Resolves with the bound <code>port</code> and the <code>server</code> instance
  * @private
  */
-export function listen(app, port, changePortIfInUse, acceptRemoteConnections) {
+export function listen(server, port, changePortIfInUse, acceptRemoteConnections) {
 	return new Promise(function(resolve, reject) {
 		const options = {};
 
@@ -51,7 +71,7 @@ export function listen(app, port, changePortIfInUse, acceptRemoteConnections) {
 			}
 
 			options.port = foundPort;
-			const server = app.listen(options, function() {
+			server.listen(options, function() {
 				resolve({port: options.port, server});
 			});
 
@@ -60,20 +80,6 @@ export function listen(app, port, changePortIfInUse, acceptRemoteConnections) {
 			});
 		});
 	});
-}
-
-/**
- * Wraps a request handler in an HTTPS server.
- *
- * @param {object} parameters
- * @param {Function} parameters.app The request handler to serve over HTTPS
- * @param {string} parameters.key Path to private key to be used for https
- * @param {string} parameters.cert Path to certificate to be used for for https
- * @returns {object} The https server
- * @private
- */
-export function addSsl({app, key, cert}) {
-	return https.createServer({key, cert}, app);
 }
 
 /**

--- a/packages/server/test/lib/server/serve/Supervisor.js
+++ b/packages/server/test/lib/server/serve/Supervisor.js
@@ -25,7 +25,10 @@ function createMocks({stacks, buildAppImpl, definitionWatcherCreate} = {}) {
 
 	const createdHandlers = [];
 	const listen = sinon.stub().resolves({port: 3000, server: httpServer});
-	const addSsl = sinon.stub().callsFake(({app}) => app);
+	const createServer = sinon.stub().callsFake((config, requestHandler) => {
+		createdHandlers.push(requestHandler);
+		return httpServer;
+	});
 	const announceListening = sinon.stub();
 
 	const liveReloadHandle = {close: sinon.stub()};
@@ -65,24 +68,14 @@ function createMocks({stacks, buildAppImpl, definitionWatcherCreate} = {}) {
 		return stackQueue.shift();
 	});
 
-	const httpMock = {
-		default: {
-			createServer: sinon.stub().callsFake((handler) => {
-				createdHandlers.push(handler);
-				return httpServer;
-			})
-		}
-	};
-
 	const mocks = {
-		"node:http": httpMock,
 		"../../../../lib/serve/stack.js": {default: buildApp},
-		"../../../../lib/serve/httpListener.js": {listen, addSsl, announceListening},
+		"../../../../lib/serve/httpListener.js": {createServer, listen, announceListening},
 		"../../../../lib/liveReload/server.js": {default: attachLiveReloadServer},
 	};
 
 	return {
-		mocks, projectWatcher, httpServer, listen, addSsl, announceListening,
+		mocks, projectWatcher, httpServer, createServer, listen, announceListening,
 		attachLiveReloadServer, liveReloadHandle, buildApp, createdHandlers,
 		ProjectDefinitionWatcher, definitionWatchers, waitForProjectGraphSettled,
 	};
@@ -188,7 +181,7 @@ test("request dispatcher retargets to the swapped app after reinitialize()", asy
 
 	const supervisor = await Supervisor.create({}, baseConfig, undefined, graphFactory);
 
-	// The stable request handler passed to http.createServer.
+	// The stable request handler passed to createServer.
 	const dispatcher = createdHandlers[0];
 	dispatcher("req", "res");
 	t.true(app1.calledOnceWithExactly("req", "res"), "routed to app1 before swap");


### PR DESCRIPTION
Add a symmetric createServer helper to httpListener.js that builds the right Node server for the config, replacing the inline http.createServer / addSsl asymmetry in Supervisor.#init. addSsl folds into createServer, and listen's parameter is renamed app -> server to reflect that it binds a pre-created server rather than an Express app.

Express now stays confined to stack.js; the Supervisor no longer imports node:http directly.
