### PR TITLE
build: Run docs build in npm test and align dev/build scripts

### DIFF
--- a/internal/documentation/package.json
+++ b/internal/documentation/package.json
@@ -24,7 +24,8 @@
 	"scripts": {
 		"start": "vitepress dev --open",
 		"lint": "eslint .",
-		"dev": "vitepress dev",
+		"dev": "npm run jsdoc-generate && npm run schema-generate && npm run generate-cli-doc && vitepress dev",
+		"build": "npm run jsdoc-generate && npm run schema-generate && npm run generate-cli-doc && npm run build:vitepress && npm run build:assets",
 		"build:vitepress": "vitepress build",
 		"build:assets": "sh -c 'DEST_DIR=${1:-./dist}; cp -r ./docs/images \"$DEST_DIR/images\"' --",
 		"preview": "vitepress preview --port 8080",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"npm": ">= 8"
 	},
 	"scripts": {
-		"test": "npm run lint && npm run check-licenses && npm run knip && npm run coverage && npm run schema-generate && npm run generate-cli-doc",
+		"test": "npm run lint && npm run check-licenses && npm run knip && npm run coverage && npm run docs:build",
 		"lint": "eslint ./ && npm run lint --workspaces --if-present",
 		"lint:commit": "commitlint",
 		"unit": "npm run unit --workspaces --if-present",
@@ -33,7 +33,8 @@
 		"knip": "knip --config knip.config.js",
 		"check-engine": "check-engine-light .",
 		"check-licenses": "licensee --errors-only",
-		"docs:dev": "npm run jsdoc-generate --workspace=@ui5/documentation && npm run generate-cli-doc --workspace=@ui5/documentation && npm run dev --workspace=@ui5/documentation",
+		"docs:dev": "npm run dev --workspace=@ui5/documentation",
+		"docs:build": "npm run build --workspace=@ui5/documentation",
 		"audit": "audit-ci --config ./audit-ci.jsonc"
 	},
 	"repository": {


### PR DESCRIPTION
The root "npm test" previously ran "schema-generate" and "generate-cli-doc" directly, but those scripts only exist in the @ui5/documentation workspace, so the command failed with "missing script". Delegate to the workspace via "docs:build" instead, which runs the full docs build (jsdoc, schema, cli-doc, vitepress).

Also add "schema-generate" to the workspace "dev" script so the dev server mirrors the build and schema changes can be previewed.
