### PR TITLE
[INTERNAL] Fix audit allowlist paths for qs advisories

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -27,9 +27,9 @@
         // Confirmed upstream in https://github.com/expressjs/express/pull/7440.
         // We cannot bump qs ourselves (transitive via express); the fix is pending an Express 4.x
         // release (expressjs/express#7439, #7440; expressjs/body-parser#761 merged but unreleased).
-        "GHSA-4mjr-xmp4-gh2g|qs>",
-        "GHSA-4mjr-xmp4-gh2g|@ui5/cli>@ui5/server>express>body-parser>qs",
-        "GHSA-x5fp-wj9c-mxmx|qs>",
-        "GHSA-x5fp-wj9c-mxmx|@ui5/cli>@ui5/server>express>body-parser>qs"
+        "GHSA-4mjr-xmp4-gh2g|@ui5/cli>@ui5/server>express>qs",
+        "GHSA-4mjr-xmp4-gh2g|body-parser>qs",
+        "GHSA-x5fp-wj9c-mxmx|@ui5/cli>@ui5/server>express>qs",
+        "GHSA-x5fp-wj9c-mxmx|body-parser>qs"
     ]
 }


### PR DESCRIPTION
Follow-up to https://github.com/UI5/cli/pull/1582 — align the qs allowlist entries with the paths npm 11 actually reports.
