### PR TITLE
ci: Update setup-node action version to v7.0.0

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -27,7 +27,7 @@ jobs:
       # comes with npm 10. This could lead to different installation paths that could conflict with the
       # allowlist in audit-ci.jsonc.
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
 


### PR DESCRIPTION
https://github.com/UI5/cli/pull/1581 introduced an outdated version.
